### PR TITLE
Add private mode for running on a WAN

### DIFF
--- a/acornaccounting/accounting/settings/base.py
+++ b/acornaccounting/accounting/settings/base.py
@@ -97,6 +97,7 @@ CONSTANCE_CONFIG = {
                        "your company's city, state and zipcode."),
     'PHONE': ('(456)555-0925', "your company's phone number."),
     'TAX_ID': ('00-0000000', "your company's federal tax id."),
+    'PRIVATE': (False, "does the site require logging in to view content"),
 }
 
 CONSTANCE_BACKEND = 'constance.backends.database.DatabaseBackend'

--- a/acornaccounting/accounts/views.py
+++ b/acornaccounting/accounts/views.py
@@ -14,12 +14,14 @@ from core.core import (today_in_american_format,
                        remove_trailing_zeroes,
                        process_month_start_date_range_form,
                        process_year_start_date_range_form)
+from core.auth import login_required_if_private
 from fiscalyears.fiscalyears import get_start_of_current_fiscal_year
 
 from .forms import AccountReconcileForm, ReconcileTransactionFormSet
 from .models import Account, Header, HistoricalAccount
 
 
+@login_required_if_private
 def quick_account_search(request):
     """Processes search for quick_account tag"""
     if 'account' in request.GET:
@@ -30,6 +32,7 @@ def quick_account_search(request):
         raise Http404
 
 
+@login_required_if_private
 def quick_bank_search(request):
     """Processes search for bank journals"""
     if 'bank' in request.GET:
@@ -42,6 +45,7 @@ def quick_bank_search(request):
         raise Http404
 
 
+@login_required_if_private
 def show_accounts_chart(request, header_slug=None,
                         template_name="accounts/account_charts.html"):
     """Retrieves self and descendant Headers or all Headers"""
@@ -56,6 +60,7 @@ def show_accounts_chart(request, header_slug=None,
     return render(request, template_name, locals())
 
 
+@login_required_if_private
 def show_account_detail(request, account_slug,
                         template_name="accounts/account_detail.html"):
     """
@@ -128,6 +133,7 @@ def show_account_detail(request, account_slug,
     return render(request, template_name, locals())
 
 
+@login_required_if_private
 def show_account_history(request, month=None, year=None,
                          template_name="accounts/account_history.html"):
     """
@@ -222,6 +228,7 @@ def show_account_history(request, month=None, year=None,
         return render(request, template_name, {'accounts': '', 'date': date})
 
 
+@login_required_if_private
 def bank_journal(request, account_slug,
                  template_name="accounts/bank_journal.html"):
     form, start_date, stop_date = process_month_start_date_range_form(request)
@@ -334,6 +341,7 @@ def reconcile_account(request, account_slug,
 
 
 @ajax
+@login_required_if_private
 def accounts_query(request):
     """AJAX endpoint for querying Account Names & Descriptions.
 

--- a/acornaccounting/core/auth.py
+++ b/acornaccounting/core/auth.py
@@ -1,0 +1,20 @@
+import urlparse
+from django.conf import settings
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.contrib.auth.decorators import user_passes_test
+from constance import config
+
+
+def login_required_if_private(function=None, redirect_field_name=REDIRECT_FIELD_NAME, login_url=None):
+    """
+    Decorator for views that redirects the user to the log-in page if the
+    site is configured to be private and the user is not logged in.
+    """
+    actual_decorator = user_passes_test(
+        lambda u: (not config.PRIVATE) or u.is_authenticated(),
+        login_url=login_url,
+        redirect_field_name=redirect_field_name
+    )
+    if function:
+        return actual_decorator(function)
+    return actual_decorator

--- a/acornaccounting/creditcards/views.py
+++ b/acornaccounting/creditcards/views.py
@@ -2,6 +2,7 @@ from django.contrib.auth.decorators import login_required
 
 from core.views import (list_entries, show_single_entry,
                         AddApprovableEntryView)
+from core.auth import login_required_if_private
 
 from .forms import CreditCardEntryForm, CreditCardTransactionFormSet
 from .models import CreditCardEntry, CreditCardReceipt
@@ -13,12 +14,14 @@ def list_creditcard_entries(request, template_name='creditcards/list.html'):
     return list_entries(request, template_name, CreditCardEntry)
 
 
+@login_required_if_private
 def show_creditcard_entry(request, entry_id,
                           template_name="creditcards/show_entry.html"):
     """View a :class:`~.models.CreditCardEntry`."""
     return show_single_entry(request, entry_id, template_name, CreditCardEntry)
 
 
+@login_required_if_private
 def add_creditcard_entry(request, entry_id=None,
                          template_name="creditcards/credit_card_form.html"):
     """Add, edit, approve or delete a :class:`~.models.CreditCardEntry`."""

--- a/acornaccounting/entries/views.py
+++ b/acornaccounting/entries/views.py
@@ -8,6 +8,7 @@ from django.shortcuts import render, get_object_or_404
 from django.utils import timezone
 
 from core.core import process_month_start_date_range_form
+from core.auth import login_required_if_private
 
 from .forms import (JournalEntryForm, BankSpendingForm, BankReceivingForm,
                     TransactionFormSet, TransferFormSet,
@@ -17,6 +18,7 @@ from .models import (Transaction, JournalEntry, BankSpendingEntry,
                      BankReceivingEntry)
 
 
+@login_required_if_private
 def journal_ledger(request, template_name="entries/journal_ledger.html"):
     """Display a list of :class:`Journal Entries<.models.JournalEntry>`.
 
@@ -33,6 +35,7 @@ def journal_ledger(request, template_name="entries/journal_ledger.html"):
     return render(request, template_name, locals())
 
 
+@login_required_if_private
 def show_journal_entry(request, entry_id,
                        template_name="entries/entry_detail.html"):
     """Display the details of a :class:`~.models.JournalEntry`.
@@ -56,6 +59,7 @@ def show_journal_entry(request, entry_id,
     return render(request, template_name, locals())
 
 
+@login_required_if_private
 def show_bank_entry(request, entry_id, journal_type):
     """
     Display the details of a :class:`~.models.BankSpendingEntry` or

--- a/acornaccounting/events/views.py
+++ b/acornaccounting/events/views.py
@@ -1,8 +1,11 @@
 from django.shortcuts import render, get_object_or_404
 
+from core.auth import login_required_if_private
+
 from .models import Event
 
 
+@login_required_if_private
 def show_event_detail(request, event_id,
                       template_name="events/event_detail.html"):
     """Shows the details of an :class:`~events.models.Event` instance.

--- a/acornaccounting/reports/views.py
+++ b/acornaccounting/reports/views.py
@@ -4,9 +4,11 @@ from django.shortcuts import render
 
 from accounts.models import Account, Header
 from core.core import process_year_start_date_range_form
+from core.auth import login_required_if_private
 from events.models import Event, HistoricalEvent
 
 
+@login_required_if_private
 def events_report(request, template_name="reports/events.html"):
     """Display all :class:`Events<events.models.Event>`.
 
@@ -21,6 +23,7 @@ def events_report(request, template_name="reports/events.html"):
     return render(request, template_name, locals())
 
 
+@login_required_if_private
 def profit_loss_report(request, template_name="reports/profit_loss.html"):
     """
     Display the Profit or Loss for a time period calculated using all Income
@@ -139,6 +142,7 @@ def _get_profit_totals(headers):
     return (gross_profit, operating_profit, net_profit)
 
 
+@login_required_if_private
 def trial_balance_report(request, template_name="reports/trial_balance.html"):
     """
     Display the state and change of all :class:`Accounts

--- a/acornaccounting/templates/tags/navigation.html
+++ b/acornaccounting/templates/tags/navigation.html
@@ -13,6 +13,8 @@
       <a class="navbar-brand" href="{% url homepage %}">{{ config.NAME }}</a>
     </div>
 
+    {% if user.is_authenticated or not config.PRIVATE %}
+
     <div class="collapse navbar-collapse" id="header-navbar-collapse-1">
       <ul class="nav navbar-nav navbar-left">
         <li class="dropdown">
@@ -69,6 +71,8 @@
           </ul>
         </li>
       </ul>
+
+    {% endif %}
     </div>
   </div>
 </header>

--- a/acornaccounting/trips/views.py
+++ b/acornaccounting/trips/views.py
@@ -2,6 +2,7 @@ from django.contrib.auth.decorators import login_required
 
 from core.views import (list_entries, show_single_entry,
                         AddApprovableEntryView)
+from core.auth import login_required_if_private
 
 from .forms import (TripEntryForm, TripTransactionFormSet,
                     TripStoreTransactionFormSet)
@@ -14,11 +15,13 @@ def list_trip_entries(request, template_name='trips/list.html'):
     return list_entries(request, template_name, TripEntry)
 
 
+@login_required_if_private
 def show_trip_entry(request, entry_id, template_name='trips/detail.html'):
     """View a :class:`~.models.TripEntry`."""
     return show_single_entry(request, entry_id, template_name, TripEntry)
 
 
+@login_required_if_private
 def add_trip_entry(request, entry_id=None, template_name='trips/form.html'):
     """Add, edit, approve or delete a :class:`~.models.TripEntry`."""
     view = AddTripEntryView()


### PR DESCRIPTION
This PR adds a config option "PRIVATE" which if set makes the site require login to access any page (or to see the accounts info in the nav header). This is intended to be set when the site is deployed on a public IP address but the commune doesn't want the finances to be public.
